### PR TITLE
Improve dsktool portability and fix some issues

### DIFF
--- a/dsktool/Makefile
+++ b/dsktool/Makefile
@@ -1,7 +1,7 @@
-CC=g++
+CC=cc
 #CC=i686-w64-mingw32-g++
 #FLAGS32=-m32
-STATIC=-static -static-libgcc -static-libstdc++
+#STATIC=-static -static-libgcc -static-libstdc++
 CCFLAGS=$(FLAGS32) $(STATIC) -Wall -O2 -fpermissive -Wunused-variable
 OUT=dsktool
 #OUT=dsktool.exe

--- a/dsktool/dsktool.c
+++ b/dsktool/dsktool.c
@@ -291,7 +291,7 @@ fileinfo_t *getfileinfo (uint16_t entrypos) {
 	// Filter entries by name
 	char *name = (char *)dir->name;
 	for (i=0; i<11; i++) {
-		if (*name < 0x20 || *name >= 0x80) return NULL;
+		if (*name < 0x20 || (*name & 0x80)) return NULL;
 		name++;
 	}
 
@@ -415,7 +415,7 @@ void list_advhdsk (void) {
 	printf ("Name of volume:   %s\n\n",name);
 	for (i=0; i<190; i++) {
 		file = getfileinfoadvh(i);
-		if (file->name[0]==0xFF) break;
+		if ((unsigned char)file->name[0]==0xFF) break;
 		printf ("%-8s.%-3s   [Diskfile Offset:%7d]  %7u bytes\n", file->name, file->ext, file->first, file->size);
 	}
 	puts("");
@@ -655,7 +655,7 @@ void add_single_file(char *name, char *pathname) {
 	//Search first empty directory entry
 	dir = rootdir;
 	for (i=0; i<bootsec->maxDirectoryEntries; i++) {
-		if (dir->name[0]<0x20 || dir->name[0]>=0x80) {
+		if (dir->name[0]<0x20 || (dir->name[0] & 0x80)) {
 			break;
 		}
 		dir++;

--- a/dsktool/dsktool.c
+++ b/dsktool/dsktool.c
@@ -3,7 +3,6 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <ctype.h>
-#include <malloc.h>
 #include <string.h>
 #include <time.h>
 #include <libgen.h>


### PR DESCRIPTION
This PR improves dsktool portability and fixes some issues:

- update dsktool/Makefile to compile dsktool on Linux and MacOS without warnings and errors
- update dsktool/dsktool.c to remove deprecated malloc.h since malloc/free are declared in stdlib.h
- update dsktool/dsktool.c to fix char signedness issues (char may or may not be signed, no assumptions should be made)

I've tested dsktool on Linux and MacOS using a 720K MSX .dsk image created with WebMSX for my ForthMSX project.

I've not tested on Windows. However, I do not expect problems, because these source code changes are minimal and follow the C/C++ standard.